### PR TITLE
Fix footer YouTube icon overlapping at small-desktop size

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -276,6 +276,9 @@ a:link, a:visited, a:active {
       a {
         -webkit-font-smoothing: antialiased;
         padding: 10px;
+        @include small-desktop {
+          padding-right: 0;
+        }
         span {
           margin: 2px 2px;
           font-size: 26px;
@@ -304,7 +307,7 @@ a:link, a:visited, a:active {
       // }
 
       @include small-desktop {
-        width: 230px;
+        width: 100%;
       }
 
       @include large-desktop {


### PR DESCRIPTION
and adjust the email list form width at that size to match.
