### PR TITLE
Link up About page footer links

### DIFF
--- a/_includes/donate_page.html
+++ b/_includes/donate_page.html
@@ -347,7 +347,7 @@ limitations under the License.
       </ul>
       <p>Per FEC requirements, Mayday PAC must use its best efforts to obtain and report the name, address, occupation, and employer of individual contributors.</p>
       <p>Contributions are not tax deductible.</p>
-      <p><a href="//mayday.us/privacy-policy">Our Privacy Policy</a></p>
+      <p><a href="/privacy-policy/">Our Privacy Policy</a></p>
     </div>
   </div>
 </div>

--- a/about_us.html
+++ b/about_us.html
@@ -58,27 +58,27 @@ permalink: /about_us/
                   Cambridge, MA 02238
                 </p>
                 <p class=
-              <p class="bullet-color"><a href="href=mailto:info@mayday.us"> info@mayday.us</a></p>
+              <p class="bullet-color"><a href="mailto:info@mayday.us"> info@mayday.us</a></p>
 
 
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 contact-info info-height">
             <h3>Email Us About</h3>
-            <p class="bullet-color">&bull;<a href="/donate/"> Donations</a></p>
-            <p class="bullet-color">&bull;<a href=""> Address change/
-              <span class="hidden-xs hidden-sm">&nbsp;&nbsp;&nbsp;&nbsp;</span>email removal</a></p>
-            <p class="bullet-color">&bull;<a href=""> Website issues</a></p>
+            <p class="bullet-color">&bull; <a href="mailto:info@mayday.us?subject=Donations">Donations</a></p>
+            <p class="bullet-color">&bull; <a href="mailto:info@mayday.us?subject=Address change / Email removal">Address change /
+              <span class="hidden-xs hidden-sm">&nbsp;&nbsp;&nbsp;&nbsp;</span>Email removal</a></p>
+            <p class="bullet-color">&bull; <a href="mailto:info@mayday.us?subject=Website issues">Website issues</a></p>
           </div>
           <div class="col-md-2 col-sm-6 col-xs-12 contact-info info-height">
             <h3>Find Us</h3>
-            <p class="bullet-color"><span class="socicon">C</span>&nbsp;&nbsp;<a href="">Reddit</a></p>
-            <p class="bullet-color"><span class="socicon">b</span>&nbsp;&nbsp;<a href="">Facebook</a></p>
-            <p class="bullet-color"><span class="socicon">a</span>&nbsp;&nbsp;<a href="">Twitter</a></p>
+            <p class="bullet-color"><span class="socicon">C</span>&nbsp;&nbsp;<a href="http://www.reddit.com/r/maydaypac">Reddit</a></p>
+            <p class="bullet-color"><span class="socicon">b</span>&nbsp;&nbsp;<a href="https://www.facebook.com/MAYDAYdotUS">Facebook</a></p>
+            <p class="bullet-color"><span class="socicon">a</span>&nbsp;&nbsp;<a href="https://twitter.com/maydayus">Twitter</a></p>
           </div>
           <div class="col-md-3 col-sm-6 col-xs-12 contact-info info-height">
             <h3>More</h3>
-            <p class="bullet-color">&bull;<a href=""> Privacy Policy</a></p>
-            <p class="bullet-color">&bull;<a href=""> Attribution</a></p>
+            <p class="bullet-color">&bull; <a href="/privacy-policy/">Privacy Policy</a></p>
+            <p class="bullet-color">&bull; <a href="/attribution/">Attribution</a></p>
           </div>
         </nav>
     </div>


### PR DESCRIPTION
Social profiles, mailto links, privacy-policy (on donate pages, too)

“Attribution” is linked up but page doesn’t yet exist (or I’m wrong about what it should link to)
