### PR TITLE
about and news page fixes

### DIFF
--- a/30_news.html
+++ b/30_news.html
@@ -20,7 +20,7 @@ permalink: /news/
           </h2>
         </div>
         <div class="panel-body contact-info">
-            <p><a href="#">Download Press Kit</a></p>
+            <p><a href="mailto:press@mayday.us?subject=Press">press@mayday.us</a></p>
           </ul>
         </div>
       </div>
@@ -34,7 +34,7 @@ permalink: /news/
         </div>
         <div class="panel-body contact-info">
           <p>
-            <a href="mailto:info@mayday.us">info@mayday.us</a>
+            <a href="mailto:info@mayday.us?subject=Info">info@mayday.us</a>
           </p>
           <p>
             MAYDAY PAC<br/>

--- a/about_us.html
+++ b/about_us.html
@@ -58,7 +58,7 @@ permalink: /about_us/
                   Cambridge, MA 02238
                 </p>
                 <p class=
-              <p class="bullet-color"><a href="mailto:info@mayday.us"> info@mayday.us</a></p>
+              <p class="bullet-color"><a href="mailto:info@mayday.us?subject=Info"> info@mayday.us</a></p>
 
 
           </div>


### PR DESCRIPTION
All links on about page and news page press and info work as desired.
